### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
 OctoprintApi	KEYWORD1
 sendGetToOctoprint	KEYWORD2
 getPrinterStatistics	KEYWORD2
-getOctoprintVersion     KEYWORD2
+getOctoprintVersion	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords