### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,22 +15,22 @@ OctoprintApi	KEYWORD1
 sendGetToOctoprint	KEYWORD2
 getPrinterStatistics	KEYWORD2
 getOctoprintVersion	KEYWORD2
-getPrintJob KEYWORD2
-octoPrintGetPrinterBed  KEYWORD2
-sendPostToOctoPrint KEYWORD2
-octoPrintConnectionDisconnect   KEYWORD2
-octoPrintConnectionAutoConnect  KEYWORD2
-octoPrintConnectionFakeAck  KEYWORD2
-octoPrintPrintHeadHome  KEYWORD2
-octoPrintGetPrinterSD   KEYWORD2
-octoPrintPrinterSDInit  KEYWORD2
-octoPrintPrinterSDRefresh   KEYWORD2
-octoPrintPrinterSDRelease   KEYWORD2
-octoPrintJobStart   KEYWORD2
-octoPrintJobCancel  KEYWORD2
-octoPrintJobRestart KEYWORD2
-octoPrintJobPauseResume KEYWORD2
-octoPrintPrinterCommand KEYWORD2
+getPrintJob	KEYWORD2
+octoPrintGetPrinterBed	KEYWORD2
+sendPostToOctoPrint	KEYWORD2
+octoPrintConnectionDisconnect	KEYWORD2
+octoPrintConnectionAutoConnect	KEYWORD2
+octoPrintConnectionFakeAck	KEYWORD2
+octoPrintPrintHeadHome	KEYWORD2
+octoPrintGetPrinterSD	KEYWORD2
+octoPrintPrinterSDInit	KEYWORD2
+octoPrintPrinterSDRefresh	KEYWORD2
+octoPrintPrinterSDRelease	KEYWORD2
+octoPrintJobStart	KEYWORD2
+octoPrintJobCancel	KEYWORD2
+octoPrintJobRestart	KEYWORD2
+octoPrintJobPauseResume	KEYWORD2
+octoPrintPrinterCommand	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords