### PR TITLE
Improve API call performance

### DIFF
--- a/OctoPrintAPI.cpp
+++ b/OctoPrintAPI.cpp
@@ -69,6 +69,7 @@ String OctoprintApi::sendGetToOctoprint(String command) {
     }
     _client->print("X-Api-Key: "); _client->println(_apiKey);
     _client->println("User-Agent: arduino/1.0");
+    _client->println("Connection: close");
     _client->println();
 
     now = millis();
@@ -106,6 +107,9 @@ String OctoprintApi::sendGetToOctoprint(String command) {
 				}else if (c != '\r') {
 					currentLineIsBlank = false;
 				}
+      }
+      if (!_client->connected()) {
+          break;
       }
     }
   }
@@ -332,6 +336,7 @@ String OctoprintApi::sendPostToOctoPrint(String command, char* postData) {
     _client->println("Content-Type: application/json");
     _client->print("X-Api-Key: "); _client->println(_apiKey);
     _client->println("User-Agent: arduino/1.0");
+    _client->println("Connection: close");
     _client->print("Content-Length: ");
     _client->println(strlen(postData));// number of bytes in the payload
     _client->println();// important need an empty line here 
@@ -372,6 +377,9 @@ String OctoprintApi::sendPostToOctoPrint(String command, char* postData) {
 				}else if (c != '\r') {
 					currentLineIsBlank = false;
 				}
+      }
+      if (!_client->connected()) {
+          break;
       }
     }
   }


### PR DESCRIPTION
Send "Connection: close" header to octoprint and abort connection read loops when connection gets closed