### PR TITLE
Add content-length check for response (to fix http client)

### DIFF
--- a/OctoPrintAPI.h
+++ b/OctoPrintAPI.h
@@ -56,7 +56,7 @@ struct printJobCall{
 };
 
 struct printerBedCall{
-  float printerBedTempActual;  
+  float printerBedTempActual;
   float printerBedTempOffset;
   float printerBedTempTarget;
   long printerBedTempHistoryTimestamp;
@@ -92,7 +92,7 @@ class OctoprintApi
 
     bool octoPrintGetPrinterBed();
     printerBedCall printerBed;
-    
+
     bool octoPrintJobStart();
     bool octoPrintJobCancel();
     bool octoPrintJobRestart();
@@ -110,6 +110,7 @@ class OctoprintApi
     const int maxMessageLength = 1000;
     void closeClient();
     int extractHttpCode(String statusCode,String body);
+    String sendRequestToOctoprint(String type, String command, char* data);
 };
 
 #endif


### PR DESCRIPTION
Another attempt to fix the http client of OctoprintAPI :-)
- switched back to "Connection: keep-alive" to avoid weird issues with new esp8266 core
- added handling of Content-length header in response, read only the advertised number of bytes from the response stream (avoids waiting for the three second timeout for every request)
- use a generic request method for both GET and POST requests to reduce code duplication
- my editor did some trailing whitespace cleanups... I hope you don't mind :-)
