### PR TITLE
Add core commands to the api for: shutdown, reboot, restart of the octoprint server

### DIFF
--- a/OctoPrintAPI.cpp
+++ b/OctoPrintAPI.cpp
@@ -288,6 +288,27 @@ bool OctoprintApi::octoPrintFileSelect(String &path) {
 
 //bool OctoprintApi::octoPrintJobPause(String actionCommand){}
 
+/***** SYSTEM COMMANDS *****/
+/**
+ * https://docs.octoprint.org/en/master/api/system.html
+ * All system operations require the SYSTEM permission.
+ * action: shutdown, reboot, restart 
+ * */
+bool OctoprintApi::octoPrintCoreShutdown() {
+  sendPostToOctoPrint("/api/system/commands/core/shutdown","");
+  return (httpStatusCode == 204);
+}
+
+bool OctoprintApi::octoPrintCoreReboot() {
+  sendPostToOctoPrint("/api/system/commands/core/reboot","");
+  return (httpStatusCode == 204);
+}
+
+bool OctoprintApi::octoPrintCoreRestart() {
+  sendPostToOctoPrint("/api/system/commands/core/restart","");
+  return (httpStatusCode == 204);
+}
+
 /** getPrintJob
  * http://docs.octoprint.org/en/master/api/job.html#retrieve-information-about-the-current-job
  * Retrieve information about the current job (if there is one).

--- a/OctoPrintAPI.h
+++ b/OctoPrintAPI.h
@@ -125,6 +125,10 @@ class OctoprintApi {
   bool octoPrintJobResume();
   bool octoPrintFileSelect(String &path);
 
+  bool octoPrintCoreShutdown();
+  bool octoPrintCoreReboot();
+  bool octoPrintCoreRestart();
+
   bool octoPrintPrinterCommand(char *gcodeCommand);
 
  private:


### PR DESCRIPTION
I wanted to use the API for a standalone electrical (wifi) plug, that can get state and temperature from the printer and can shutdown the Pi and power off (with its own relay)

I missed the "core" command to shutdown, which is in the API.

I added "shutdown", "reboot" and "restart" methods to the api:
  bool octoPrintCoreShutdown();
  bool octoPrintCoreReboot();
  bool octoPrintCoreRestart();

I included them in my test sketch, and all three had the desired effect.