### PR TITLE
Updates for run time init

### DIFF
--- a/OctoPrintAPI.cpp
+++ b/OctoPrintAPI.cpp
@@ -11,21 +11,36 @@
 
 #include "Arduino.h"
 
+OctoprintApi::OctoprintApi(void){
+	if (_debug)
+		Serial.println("Be sure to Call init to setup and start the OctoprintApi instance");
+	
+}
+
 /** OctoprintApi()
  * IP address version of the client connect function
  * */
 OctoprintApi::OctoprintApi(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey) {
+  init(client, octoPrintIp, octoPrintPort, apiKey);
+}
+
+void OctoprintApi::init(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey) {
   _client         = &client;
   _apiKey         = apiKey;
   _octoPrintIp    = octoPrintIp;
   _octoPrintPort  = octoPrintPort;
   _usingIpAddress = true;
-}
+} 
 
 /** OctoprintApi()
  * Hostname version of the client connect function
  * */
+ 
 OctoprintApi::OctoprintApi(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey) {
+	init(client, octoPrintUrl,octoPrintPort,apiKey);
+}
+
+void OctoprintApi::init(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey) {
   _client         = &client;
   _apiKey         = apiKey;
   _octoPrintUrl   = octoPrintUrl;

--- a/OctoPrintAPI.h
+++ b/OctoPrintAPI.h
@@ -85,8 +85,11 @@ struct printerBedCall {
 
 class OctoprintApi {
  public:
+  OctoprintApi(void);
   OctoprintApi(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey);
   OctoprintApi(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey);
+  void init(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey);
+  void init(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey);
   String sendGetToOctoprint(String command);
   String getOctoprintEndpointResults(String command);
   bool getPrinterStatistics();

--- a/examples/ESP32/HelloWorldSerial/HelloWorldSerial.ino
+++ b/examples/ESP32/HelloWorldSerial/HelloWorldSerial.ino
@@ -42,6 +42,7 @@ String printerTarget;
 String payload;
 
 // Use one of the following:
+//OctoprintApi api; //Be sure to call init in setup.
 OctoprintApi api(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
 // OctoprintApi api(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
 
@@ -74,6 +75,11 @@ void setup () {
   Serial.println("WiFi connected");
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
+  
+  //Use one of these Only if you have not initialized the api object above with parameters"
+  //api.init(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
+  //api.init(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
+  
 }
 
 

--- a/examples/ESP8266/GetPrintJobInfo/GetPrintJobInfo.ino
+++ b/examples/ESP8266/GetPrintJobInfo/GetPrintJobInfo.ino
@@ -35,6 +35,7 @@ const int octoprint_httpPort = 80;  //If you are connecting through a router thi
 String octoprint_apikey = "API_KEY"; //See top of file or GIT Readme about getting API key
 
 // Use one of the following:
+//OctoprintApi api; //Be sure to call init in setup.
 OctoprintApi api(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
 // OctoprintApi api(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
 
@@ -67,6 +68,12 @@ void setup () {
   Serial.println("WiFi connected");  
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP()); 
+  
+  //Use one of these Only if you have not initialized the api object above with parameters"
+  //api.init(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
+  //api.init(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
+  
+  
 }
 
 

--- a/examples/ESP8266/HelloWorldSerial/HelloWorldSerial.ino
+++ b/examples/ESP8266/HelloWorldSerial/HelloWorldSerial.ino
@@ -42,8 +42,9 @@ String printerTarget;
 String payload;
 
 // Use one of the following:
-OctoprintApi api(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
-// OctoprintApi api(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
+OctoprintApi api; //Be sure to call init in setup. 
+//OctoprintApi api(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
+//OctoprintApi api(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
 
 unsigned long api_mtbs = 60000; //mean time between api requests (60 seconds)
 unsigned long api_lasttime = 0;   //last time api request has been done
@@ -74,6 +75,11 @@ void setup () {
   Serial.println("WiFi connected");
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
+
+  //Use one of these Only if you have not initialized the api object above with parameters"
+  api.init(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
+  //api.init(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
+  
 }
 
 

--- a/examples/ESP8266/WS2812BProgress/WS2812BProgress.ino
+++ b/examples/ESP8266/WS2812BProgress/WS2812BProgress.ino
@@ -49,6 +49,7 @@ long printed_timeout = 3600000; //60 mins in milliseconds - timeout after printi
 long printed_timeout_timer = printed_timeout;
 
 // Use one of the following:
+//OctoprintApi api; //Be sure to call init in setup. 
 OctoprintApi api(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
 //OctoprintApi api(client, octoprint_host, octoprint_httpPort, octoprint_apikey); //If using hostname. Comment out one or the other.
 
@@ -100,6 +101,12 @@ void setup() {
       connection_retry++;
     }
   }
+  
+  //Use one of these Only if you have not initialized the api object above with parameters"
+  //api.init(client, ip, octoprint_httpPort, octoprint_apikey);               //If using IP address
+  //api.init(client, octoprint_host, octoprint_httpPort, octoprint_apikey);//If using hostname. Comment out one or the other.
+  
+  
   //if you get here you have connected to the WiFi
   fill_solid(leds, NUM_LEDS, CRGB::Black);
   FastLED.show();

--- a/keywords.txt
+++ b/keywords.txt
@@ -35,6 +35,7 @@ octoPrintPrinterCommand	KEYWORD2
 octoPrintJobPause	KEYWORD2
 octoPrintJobResume	KEYWORD2
 octoPrintFileSelect	KEYWORD2
+init	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
These changes allow for runtime initialization of the API object. This way one can pull info like the url or port for connection to a specific Octoprint instance from settings file on SD or in EE.  There are no breaking changes. All existing implementations will continue to work as expected without any need for change. 

Added 3 new methods. (code comments not in actual code)
```
class OctoprintApi {
 public:
  OctoprintApi(void); //new
  OctoprintApi(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey); //existing
  OctoprintApi(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey); //existing
  void init(Client &client, char *octoPrintUrl, int octoPrintPort, String apiKey); //new 
  void init(Client &client, IPAddress octoPrintIp, int octoPrintPort, String apiKey); //new

```
I also updated the existing examples and the keywords.txt as approprate.



