### PR TITLE
Populate the HttpErrorBody String on an Http Error code

### DIFF
--- a/OctoPrintAPI.cpp
+++ b/OctoPrintAPI.cpp
@@ -153,6 +153,7 @@ String OctoprintApi::sendRequestToOctoprint(String type, String command, const c
     Serial.println(httpCode);
   }
   httpStatusCode = httpCode;
+  if(httpStatusCode <= 199 || httpStatusCode >= 300){httpErrorBody = body;} //account for any error codes. Client can decide what to do with Body Contents as a fall back.
 
   return body;
 }


### PR DESCRIPTION
A simple change to populate the public String HttpErrorBody

With this update a client will have the ability to know a little more about the error response. Maybe parse out the body and display something readable or at the very least just log the response body in as is. 

The property is already present, HttpErrorBody, it was just not being populated. 